### PR TITLE
Add cache support for GNAT Community installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # Ada toolchain installation Action
 
+This action install an Ada development environment.
+
+## Inputs
+### `distrib`
+The development environment distribution. Could be `fsf` (default) or `community`.
+
+### `target`
+The compiler target. Could be `native` (default), `arm-elf` or `riscv32-elf`.
+Currently `fsf` distribution supports only `native` target.
+
+### `community_year`
+The version of `community` environment. Value: `2020`, `2019`. Default is the most recent.
+
+### `install_dir`
+Path to a directory to install a `community` distribution. Default is a temporary folder.
+This could be used together with the `actions/cache` action to cache the installation.
+See an example below.
+
 ## Getting Started
 
-Basic:
+### Using the native FSF GNAT and the GNAT Community ARM cross compiler:
 ```yaml
 steps:
 - uses: actions/checkout@master
@@ -15,6 +33,21 @@ steps:
   with:
     distrib: community
     target: arm-elf
+- run: gprbuild --target=arm-eabi --RTS=zfp-microbit hello
+```
+
+### Using the GNAT Community and a cache directory
+```yaml
+steps:
+- uses: actions/cache@v2
+  with:
+    path: ./cached_gnat
+    key: ${{ runner.os }}-gnat-ce-2020
+- uses: ada-actions/toolchain@dev
+  with:
+    distrib: community
+    target: arm-elf
+    install_dir: ./cached_gnat
 - run: gprbuild --target=arm-eabi --RTS=zfp-microbit hello
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   community_year:
     description: 'Year of the community release (2020, 2019)'
     default: '2020'
+  install_dir:
+    description: 'Path to a directory to install a community release'
+    default: ''
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,6 +19,7 @@ const core = __importStar(require("@actions/core"));
 const io = __importStar(require("@actions/io"));
 const tc = __importStar(require("@actions/tool-cache"));
 const exec = __importStar(require("@actions/exec"));
+const fs = __importStar(require("fs"));
 const path = require("path");
 const sha1File = require('sha1-file');
 const IS_WINDOWS = process.platform === 'win32';
@@ -35,7 +36,7 @@ function download(url, dest) {
     });
 }
 ;
-function installGNATCommunity(year, target) {
+function installGNATCommunity(year, target, install_dir) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!community_configs[process.platform]) {
             core.setFailed(`Unknown platform '${process.platform}' for GNAT community`);
@@ -53,6 +54,12 @@ function installGNATCommunity(year, target) {
         var pack = release.pack;
         var url = release.url;
         var sha1 = release.sha1;
+        const bin = path.resolve(install_dir, pack, 'bin');
+        if (install_dir != '' && fs.existsSync(bin)) {
+            console.log(`Package found: '${bin}'. Skip installation.`);
+            core.addPath(bin);
+            return;
+        }
         console.log("Downloading '" + url + "'");
         const dlFile = yield tc.downloadTool(url);
         if (sha1File(dlFile) != sha1) {
@@ -60,9 +67,11 @@ function installGNATCommunity(year, target) {
             return;
         }
         const tmpDir = path.dirname(dlFile);
-        const installDir = path.join(tmpDir, pack);
+        const installDir = (install_dir == '') ? path.join(tmpDir, pack)
+            : path.resolve(install_dir, pack);
         const script_qs = path.join(tmpDir, "install_script.qs");
         const script_sh = path.join(tmpDir, "install_package.sh");
+        yield io.mkdirP(installDir);
         console.log("Installing: '" + dlFile + "' in '" + installDir + "'");
         yield download(install_script_qs_url, script_qs);
         if (IS_WINDOWS) {
@@ -106,7 +115,8 @@ function run() {
                     break;
                 case "community":
                     const year = core.getInput('community_year');
-                    yield installGNATCommunity(year, target);
+                    const install_dir = core.getInput('install_dir');
+                    yield installGNATCommunity(year, target, install_dir);
                     break;
                 default:
                     core.setFailed(`Unknown distrib: '${distrib}'`);


### PR DESCRIPTION
The cache will speedup GNAT Community installation. The action checks if `<cache>/bin` exists and skip installation (just update `PATH`) in this case.